### PR TITLE
Change default backend port to 3001

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3001;
 //Define route
 app.get('/', (req: Request, res: Response) => {
   res.send('Hello, World!');


### PR DESCRIPTION
The default port of the backend is 3000, which is the same as the default frontend port. Changing to 3001 will prevent conflicts.