### PR TITLE
User can update their preferences and data will be updated in the database

### DIFF
--- a/backend/src/controllers/PreferenceController.ts
+++ b/backend/src/controllers/PreferenceController.ts
@@ -55,7 +55,7 @@ export default class PreferenceController {
   /**
    * Get all preferences of a user.
    */
-  public static async getPreferences(
+  public static async getPreferencesByUserId(
     req: Request,
     res: Response
   ): Promise<any> {
@@ -68,6 +68,7 @@ export default class PreferenceController {
           user_id: userId,
         },
       });
+
       res.json(preferences);
     } catch (error: any) {
       res

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,16 +1,8 @@
-import { Request, Response, NextFunction } from 'express';
 import AuthController from '../controllers/AuthController.ts';
 
 // Creates the router
 const express = require('express');
 const router = express.Router();
-
-// Keeps track of time on website
-const timeLog = (req: Request, res: Response, next: NextFunction) => {
-  console.log('Time: ', Date.now());
-  next();
-};
-router.use(timeLog);
 
 // Sign In route
 router.post('/signin', AuthController.signIn);

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -1,17 +1,8 @@
-// import {Router} from 'express';
-import { Request, Response, NextFunction } from 'express';
 import PreferenceController from '../controllers/PreferenceController';
 
 // Creates the router
 const express = require('express');
 const router = express.Router();
-
-// Keeps track of time on website
-const timeLog = (req: Request, res: Response, next: NextFunction) => {
-  console.log('Time: ', Date.now());
-  next();
-};
-router.use(timeLog);
 
 // Save survey results to database
 router.post('/surveyresults/:user_id', PreferenceController.postPreferences);
@@ -19,6 +10,11 @@ router.post('/surveyresults/:user_id', PreferenceController.postPreferences);
 router.get(
   '/surveyresults/:user_id',
   PreferenceController.getPreferencesByUserId
+);
+// Update survey results in database
+router.put(
+  '/surveyresults/:user_id',
+  PreferenceController.putPreferenceByUserId
 );
 
 export default router;

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -16,6 +16,9 @@ router.use(timeLog);
 // Save survey results to database
 router.post('/surveyresults/:user_id', PreferenceController.postPreferences);
 // Get all survey results from database
-router.get('/surveyresults/:user_id', PreferenceController.getPreferences);
+router.get(
+  '/surveyresults/:user_id',
+  PreferenceController.getPreferencesByUserId
+);
 
 export default router;

--- a/frontend/src/components/UserPreferencesForm.tsx
+++ b/frontend/src/components/UserPreferencesForm.tsx
@@ -19,9 +19,7 @@ import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardContent } from './ui/card';
 import axios from 'axios';
 import { useAuth } from '@/components/context/auth/AuthContext';
-
-const URL = process.env.NEXT_APP_BACKEND_BASE_URL || 'http://localhost:3001';
-
+import { backendBaseUrl } from '@/lib/utils';
 //Define form shema
 export const formSchema = z
   .object({
@@ -108,7 +106,7 @@ export function UserPreferencesForm({
       if (!user?.uid) return;
 
       axios
-        .post(URL + `/api/user/surveyresults/${user.uid}`, outputs)
+        .post(backendBaseUrl + `/api/user/surveyresults/${user.uid}`, outputs)
         .then((response) => {
           console.log('Successfully posted answers for user: ', user!.uid);
           console.log(response);

--- a/frontend/src/components/UserPreferencesForm.tsx
+++ b/frontend/src/components/UserPreferencesForm.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardContent } from './ui/card';
 import axios from 'axios';
 import { useAuth } from '@/components/context/auth/AuthContext';
-import { backendBaseUrl } from '@/lib/utils';
+import { backendBaseUrl, minutesToTime } from '@/lib/utils';
 //Define form shema
 export const formSchema = z
   .object({
@@ -246,12 +246,4 @@ export function UserPreferencesForm({
       <CardContent>{content}</CardContent>
     </Card>
   );
-}
-
-function minutesToTime(mins: number) {
-  const h = Math.floor(mins / 60)
-    .toString()
-    .padStart(2, '0');
-  const m = (mins % 60).toString().padStart(2, '0');
-  return `${h}:${m}`;
 }

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -10,7 +10,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { UserPreferencesForm, formSchema } from './UserPreferencesForm';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { z } from 'zod';
 import { useAuth } from '@/components/context/auth/AuthContext';
 import axios from 'axios';
@@ -32,6 +32,13 @@ export default function ProfilePage() {
   const [displayName, setDisplayName] = useState(
     user?.displayName || 'Studious Student'
   );
+
+  // Runs after the component mounts or user changes
+  useEffect(() => {
+    if (user?.displayName) {
+      setDisplayName(user.displayName);
+    }
+  }, [user]);
 
   // Fetch preferences when user is available
   useEffect(() => {
@@ -58,27 +65,26 @@ export default function ProfilePage() {
   // Handle the save preference logic
   function handleSavePreferences(values: z.infer<typeof formSchema>): void {
     console.log('Updated preferences:', values);
-    // TODO: Need to update the preferences in the backend. Use PUT instead of POST
-    // const outputs = [];
-    // for (const question in values) {
-    //   outputs.push({
-    //     question_text: question,
-    //     answer: String(values[question as keyof z.infer<typeof formSchema>]),
-    //   });
-    // }
-    // console.log(outputs);
-    // // Send the data to our backend
-    // if (!user?.uid) return;
-    //
-    // axios
-    //   .post(backendBaseUrl + `/api/user/surveyresults/${user.uid}`, outputs)
-    //   .then((response) => {
-    //     console.log('Successfully posted answers for user: ', user!.uid);
-    //     console.log(response);
-    //   })
-    //   .catch((error) => {
-    //     console.log(error);
-    //   });
+    const outputs = [];
+    for (const question in values) {
+      outputs.push({
+        question_text: question,
+        answer: String(values[question as keyof z.infer<typeof formSchema>]),
+      });
+    }
+    console.log(outputs);
+    // Send the data to our backend
+    if (!user?.uid) return;
+
+    axios
+      .put(backendBaseUrl + `/api/user/surveyresults/${user.uid}`, outputs)
+      .then((response) => {
+        console.log('Successfully updated answers for user: ', user!.uid);
+        console.log(response);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
     // Update state of user preference
     setUserPreferences(values);
     // Close the dialog after save
@@ -99,7 +105,9 @@ export default function ProfilePage() {
       <div className="relative z-10 max-w-3xl w-full mx-4 bg-white dark:bg-gray-900 rounded-3xl shadow-xl p-10 flex flex-col items-center gap-6 border dark:border-gray-700">
         {/* User Icon */}
         <div className="p-4 bg-white dark:bg-gray-800 rounded-full shadow-lg -mt-24">
-          <UserIcon className="w-20 h-20 text-gray-700 dark:text-gray-200" />
+          <button onClick={() => console.log(user!.displayName)}>
+            <UserIcon className="w-20 h-20 text-gray-700 dark:text-gray-200" />
+          </button>
         </div>
 
         {/* User Name */}
@@ -137,10 +145,6 @@ export default function ProfilePage() {
         {/*<h1 className="text-3xl font-bold text-gray-900 dark:text-white">*/}
         {/*  {displayName}*/}
         {/*</h1>*/}
-
-        {/*<div>*/}
-        {/*  <EditIcon className="w-20 h-20 text-gray-700 dark:text-gray-200" />*/}
-        {/*</div>*/}
 
         {/* User Preferences */}
         <div className="w-full space-y-4 text-gray-700 dark:text-gray-300 text-lg">

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -18,15 +18,6 @@ import { backendBaseUrl, formatTime } from '@/lib/utils';
 import { getPreferenceExtractData } from '@/lib/get-preference-extract-data';
 import { updateProfile } from 'firebase/auth';
 
-// Mock Data
-const mockUserData = {
-  productiveTime: [540, 720],
-  workDuration: 60,
-  sleepHours: 8,
-  startTime: '09:00',
-  endTime: '17:00',
-};
-
 export default function ProfilePage() {
   const { user, loading } = useAuth();
   // Using state to hold user preferences
@@ -63,11 +54,6 @@ export default function ProfilePage() {
       fetchPreferences().then();
     }
   }, [user, loading]);
-
-  // Handle the edit name logic
-  function handleEditName() {
-    setEditMode(true);
-  }
 
   // Handle the save preference logic
   function handleSavePreferences(values: z.infer<typeof formSchema>): void {

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -72,26 +72,27 @@ export default function ProfilePage() {
   // Handle the save preference logic
   function handleSavePreferences(values: z.infer<typeof formSchema>): void {
     console.log('Updated preferences:', values);
-    const outputs = [];
-    for (const question in values) {
-      outputs.push({
-        question_text: question,
-        answer: String(values[question as keyof z.infer<typeof formSchema>]),
-      });
-    }
-    console.log(outputs);
-    // Send the data to our backend
-    if (!user?.uid) return;
-
-    axios
-      .post(backendBaseUrl + `/api/user/surveyresults/${user.uid}`, outputs)
-      .then((response) => {
-        console.log('Successfully posted answers for user: ', user!.uid);
-        console.log(response);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+    // TODO: Need to update the preferences in the backend. Use PUT instead of POST
+    // const outputs = [];
+    // for (const question in values) {
+    //   outputs.push({
+    //     question_text: question,
+    //     answer: String(values[question as keyof z.infer<typeof formSchema>]),
+    //   });
+    // }
+    // console.log(outputs);
+    // // Send the data to our backend
+    // if (!user?.uid) return;
+    //
+    // axios
+    //   .post(backendBaseUrl + `/api/user/surveyresults/${user.uid}`, outputs)
+    //   .then((response) => {
+    //     console.log('Successfully posted answers for user: ', user!.uid);
+    //     console.log(response);
+    //   })
+    //   .catch((error) => {
+    //     console.log(error);
+    //   });
     // Update state of user preference
     setUserPreferences(values);
     // Close the dialog after save

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -10,7 +10,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { UserPreferencesForm, formSchema } from './UserPreferencesForm';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { z } from 'zod';
 import { useAuth } from '@/components/context/auth/AuthContext';
 import axios from 'axios';

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { UserIcon } from 'lucide-react';
+import { EditIcon, UserIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -14,8 +14,9 @@ import { useEffect, useState } from 'react';
 import { z } from 'zod';
 import { useAuth } from '@/components/context/auth/AuthContext';
 import axios from 'axios';
-
-const URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3000';
+import { backendBaseUrl, formatTime } from '@/lib/utils';
+import { getPreferenceExtractData } from '@/lib/get-preference-extract-data';
+import { updateProfile } from 'firebase/auth';
 
 // Mock Data
 const mockUserData = {
@@ -26,21 +27,20 @@ const mockUserData = {
   endTime: '17:00',
 };
 
-function formatTime(minutes: number) {
-  const h = Math.floor(minutes / 60)
-    .toString()
-    .padStart(2, '0');
-  const m = (minutes % 60).toString().padStart(2, '0');
-  return `${h}:${m}`;
-}
-
 export default function ProfilePage() {
   const { user, loading } = useAuth();
-
   // Using state to hold user preferences
-  const [userPreferences, setUserPreferences] = useState(mockUserData); // Replace this with actual data
+  const [userPreferences, setUserPreferences] = useState<ReturnType<
+    typeof getPreferenceExtractData
+  > | null>(null);
   // Using state to open page
   const [open, setOpen] = useState(false);
+  // Using state to set edit username
+  const [editMode, setEditMode] = useState(false);
+  // Using state to set display name
+  const [displayName, setDisplayName] = useState(
+    user?.displayName || 'Studious Student'
+  );
 
   // Fetch preferences when user is available
   useEffect(() => {
@@ -49,25 +49,49 @@ export default function ProfilePage() {
         if (!user?.uid) return;
 
         const res = await axios.get(
-          `${URL}/api/user/surveyresults/${user.uid}`
+          backendBaseUrl + `/api/user/surveyresults/${user.uid}`
         );
-        setUserPreferences(res.data); // make sure your backend returns the correct structure
+
+        const extractedData = getPreferenceExtractData(res.data);
+        setUserPreferences(extractedData);
       } catch (err) {
         console.error('Failed to fetch user preferences:', err);
       }
     };
 
     if (!loading && user) {
-      fetchPreferences().then(() => {
-        console.log('Fetched user preferences:', userPreferences);
-      });
+      fetchPreferences().then();
     }
   }, [user, loading]);
+
+  // Handle the edit name logic
+  function handleEditName() {
+    setEditMode(true);
+  }
 
   // Handle the save preference logic
   function handleSavePreferences(values: z.infer<typeof formSchema>): void {
     console.log('Updated preferences:', values);
+    const outputs = [];
+    for (const question in values) {
+      outputs.push({
+        question_text: question,
+        answer: String(values[question as keyof z.infer<typeof formSchema>]),
+      });
+    }
+    console.log(outputs);
+    // Send the data to our backend
+    if (!user?.uid) return;
 
+    axios
+      .post(backendBaseUrl + `/api/user/surveyresults/${user.uid}`, outputs)
+      .then((response) => {
+        console.log('Successfully posted answers for user: ', user!.uid);
+        console.log(response);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
     // Update state of user preference
     setUserPreferences(values);
     // Close the dialog after save
@@ -92,9 +116,44 @@ export default function ProfilePage() {
         </div>
 
         {/* User Name */}
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-          {user?.displayName}
-        </h1>
+        <div className="flex items-center space-x-2">
+          {editMode ? (
+            <input
+              type="text"
+              className="text-3xl font-bold bg-transparent border-b border-gray-400 dark:border-gray-600 focus:outline-none focus:border-pink-500 text-gray-900 dark:text-white"
+              value={displayName}
+              onChange={async (e) => {
+                setDisplayName(e.target.value);
+                await updateProfile(user!, {
+                  displayName: e.target.value,
+                });
+              }}
+              onBlur={() => setEditMode(false)}
+              autoFocus
+            />
+          ) : (
+            <>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+                {displayName}
+              </h1>
+              <button
+                onClick={() => setEditMode(true)}
+                className="text-gray-500 hover:text-pink-500"
+                aria-label="Edit Name"
+              >
+                <EditIcon className="w-4 h-4" />
+              </button>
+            </>
+          )}
+        </div>
+
+        {/*<h1 className="text-3xl font-bold text-gray-900 dark:text-white">*/}
+        {/*  {displayName}*/}
+        {/*</h1>*/}
+
+        {/*<div>*/}
+        {/*  <EditIcon className="w-20 h-20 text-gray-700 dark:text-gray-200" />*/}
+        {/*</div>*/}
 
         {/* User Preferences */}
         <div className="w-full space-y-4 text-gray-700 dark:text-gray-300 text-lg">

--- a/frontend/src/components/ui/auth/SignUp.tsx
+++ b/frontend/src/components/ui/auth/SignUp.tsx
@@ -22,9 +22,18 @@ export default function SignUpForm() {
     try {
       await signUp(email, password);
 
+      if (!user) {
+        setErrorMessage('User not found');
+        return;
+      }
+
       // Update the user's display name
-      await updateProfile(user!, {
+      // TODO: this doesn't work because user is not yet authenticated. Maybe try
+      // TODO: to save displayName to cookie then update once user is authenticated
+      await updateProfile(user, {
         displayName: displayName,
+      }).then(() => {
+        console.log('Display name updated: ', user.displayName);
       });
 
       // 3. Get the Firebase ID token

--- a/frontend/src/lib/get-preference-extract-data.ts
+++ b/frontend/src/lib/get-preference-extract-data.ts
@@ -1,4 +1,11 @@
-export function getPreferenceExtractData(data: any) {
+interface UserPreferenceData {
+  id: string;
+  user_id: string;
+  question_id: string;
+  answer: string;
+}
+
+export function getPreferenceExtractData(data: UserPreferenceData[]) {
   const returnedData = {
     productiveTime: [0, 0],
     workDuration: 0,
@@ -7,7 +14,7 @@ export function getPreferenceExtractData(data: any) {
     endTime: '',
   };
 
-  data.forEach((item: any) => {
+  data.forEach((item: UserPreferenceData) => {
     const { question_id, answer } = item;
 
     switch (question_id) {

--- a/frontend/src/lib/get-preference-extract-data.ts
+++ b/frontend/src/lib/get-preference-extract-data.ts
@@ -1,0 +1,35 @@
+export function getPreferenceExtractData(data: any) {
+  const returnedData = {
+    productiveTime: [0, 0],
+    workDuration: 0,
+    sleepHours: 0,
+    startTime: '',
+    endTime: '',
+  };
+
+  data.forEach((item: any) => {
+    const { question_id, answer } = item;
+
+    switch (question_id) {
+      case 'pt': {
+        const times = answer.split(',').map((t: string) => parseInt(t, 10));
+        returnedData.productiveTime = [times[0], times[1]];
+        break;
+      }
+      case 'wd':
+        returnedData.workDuration = parseInt(answer, 10);
+        break;
+      case 'sh':
+        returnedData.sleepHours = parseInt(answer, 10);
+        break;
+      case 'st':
+        returnedData.startTime = answer;
+        break;
+      case 'et':
+        returnedData.endTime = answer;
+        break;
+    }
+  });
+
+  return returnedData;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,17 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+export const backendBaseUrl =
+  process.env.NEXT_APP_BACKEND_BASE_URL || 'http://localhost:3001';
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export function formatTime(minutes: number) {
+  const h = Math.floor(minutes / 60)
+    .toString()
+    .padStart(2, '0');
+  const m = (minutes % 60).toString().padStart(2, '0');
+  return `${h}:${m}`;
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -15,3 +15,11 @@ export function formatTime(minutes: number) {
   const m = (minutes % 60).toString().padStart(2, '0');
   return `${h}:${m}`;
 }
+
+export function minutesToTime(mins: number) {
+  const h = Math.floor(mins / 60)
+    .toString()
+    .padStart(2, '0');
+  const m = (mins % 60).toString().padStart(2, '0');
+  return `${h}:${m}`;
+}


### PR DESCRIPTION
# Changes made

## Backend

- `PreferenceController` now has `getPreferenceByUserId` which returns an array of `user_preferences` objects queried by `user_id`.
- It also has `putPreferenceByUserId` which takes in same input as `POST` but update the data in the table.

## Frontend

- `UserProfile`  now fetches from the backend upon routing or refresh
- `UserProfile` has an edit username that saves to user auth's displayname. It renders `user.displayName` once `user` is available.
- `UserProfile`, upon clicking `Save preference` after editting, data will be send to backend via `PUT`.

# Manually Tested

These changes have been tested using these 2 flows:

1. New user signed up -> routed to `/dashboard` and saw that their preferences are saved. They can edit and save their  new preferences. They can change their display name.
2. User signed in -> go to `/dashboard` and saw that their changes are saved, meaning that the updated preferences shown, not the initial survey. Their new display name is saved.