### PR TITLE
78 change time format in preference form to standard time

### DIFF
--- a/frontend/src/app/dashboard/calendar/page.tsx
+++ b/frontend/src/app/dashboard/calendar/page.tsx
@@ -162,7 +162,7 @@ export default function Home() {
             className="ml-8 w-full border-2 p-2 rounded-md mt-16 lg:h-1/2 bg-violet-50"
           >
             <h1 className="font-bold text-lg text-center">Drag Event</h1>
-            
+
             {events.map((event) => (
               <div
                 className="fc-event border-2 p-1 m-2 w-full rounded-md ml-auto text-center bg-white dark:bg-black"

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,20 +1,28 @@
-import { cookies } from "next/headers"
-import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/app-sidebar";
+import { cookies } from 'next/headers';
+import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
+import { AppSidebar } from '@/components/app-sidebar';
 
-export default async function Layout({ children }: { children: React.ReactNode }) {
-  const cookieStore = await cookies()
-  const defaultOpen = cookieStore.get("sidebar_state")?.value === "true"
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const cookieStore = await cookies();
+  const defaultOpen = cookieStore.get('sidebar_state')?.value === 'true';
 
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
-      <div className="flex h-screen w-full"> {/* Add this flex container */}
+      <div className="flex h-screen w-full">
+        {' '}
+        {/* Add this flex container */}
         <AppSidebar />
-        <main className="flex-1 overflow-auto"> {/* Make main take remaining space */}
-         <SidebarTrigger /> 
+        <main className="flex-1 overflow-auto">
+          {' '}
+          {/* Make main take remaining space */}
+          <SidebarTrigger />
           {children}
         </main>
       </div>
     </SidebarProvider>
-  )
+  );
 }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 // dashboard page defaults to calendar
-import Home from "./calendar/page";
+import Home from './calendar/page';
 // Authenticated pages
 // are protected by the middleware
 export default function Dashboard() {

--- a/frontend/src/app/dashboard/profilepage/page.tsx
+++ b/frontend/src/app/dashboard/profilepage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 // Onboarding form
-import ProfilePage from "@/components/UserProfile";
+import ProfilePage from '@/components/UserProfile';
 export default function Page() {
-    return <ProfilePage />;
+  return <ProfilePage />;
 }

--- a/frontend/src/components/UserPreferencesForm.tsx
+++ b/frontend/src/components/UserPreferencesForm.tsx
@@ -167,7 +167,7 @@ export function UserPreferencesForm({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Work Duration</FormLabel>
-              <FormDescription>How long do you want to work?</FormDescription>
+              <FormDescription>How long do you want to work?(in minutes)</FormDescription>
               <FormControl>
                 <Input placeholder="e.g., 3" {...field} />
               </FormControl>
@@ -184,7 +184,7 @@ export function UserPreferencesForm({
             <FormItem>
               <FormLabel>Preferred Sleep Amount</FormLabel>
               <FormDescription>
-                How much sleep do you typically get?
+                Roughly how many hours do you typically get?
               </FormDescription>
               <FormControl>
                 <Input type="number" step="0.5" placeholder="8" {...field} />

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Calendar, UserIcon} from 'lucide-react';
+import { Calendar, UserIcon } from 'lucide-react';
 
 import {
   Sidebar,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -16,10 +16,11 @@ export function formatTime(minutes: number) {
   return `${h}:${m}`;
 }
 
+// minutetoTime return function in AM/PM format
 export function minutesToTime(mins: number) {
-  const h = Math.floor(mins / 60)
-    .toString()
-    .padStart(2, '0');
-  const m = (mins % 60).toString().padStart(2, '0');
-  return `${h}:${m}`;
+  const hours24 = Math.floor(mins / 60);
+  const minutes = mins % 60;
+  const hours12 = hours24 % 12 || 12; // converts 0 -> 12, 13 -> 1
+  const ampm = hours24 < 12 ? 'AM' : 'PM';
+  return `${hours12}:${minutes.toString().padStart(2, '0')} ${ampm}`;
 }


### PR DESCRIPTION
**Time Selection:** The slider for productive time shows values in military time, which may be unfamiliar for some users. Converted it to standard AM/PM time to help improve clarity and accessibility.

**Work Duration & Sleep Hours:** Users are struggling to enter valid values for "Work Duration" and "Sleep Hours."
specified that "Work Duration" is in minutes and "Sleep Hours" should be entered as a number of hours to help reduce confusion.