### PR TITLE
Fixed bug of scheduler generated events overlapping with scheduled events

### DIFF
--- a/backend/src/utils/Scheduler.ts
+++ b/backend/src/utils/Scheduler.ts
@@ -301,14 +301,15 @@ export default class Scheduler {
     // Filter events that start after given time and before end of work day
     const currentMinutes = UserPreferenceUtils.dateToMinuteNumber(time);
     const dayEnd = userPreferences.endTime;
-    const futureEvents = events
+    const minutesToDayEnd = dayEnd - currentMinutes;
+    const dayEndDate = new Date(time.getTime() + minutesToDayEnd * 60000);
+
+    const futureEventsOnThisDay = events
       .filter(
         (event) =>
           event &&
           event.start_time >= time &&
-          event.start_time < new Date(time.getDate() + 1) &&
-          UserPreferenceUtils.dateToMinuteNumber(event.start_time) <
-            userPreferences.endTime
+          event.start_time < dayEndDate
       )
       .sort(
         (a, b) =>
@@ -316,13 +317,14 @@ export default class Scheduler {
           UserPreferenceUtils.dateToMinuteNumber(b.start_time)
       );
 
-    if (futureEvents.length > 0) {
-      return (
-        UserPreferenceUtils.dateToMinuteNumber(futureEvents[0].start_time) -
-        currentMinutes
+    if (futureEventsOnThisDay.length > 0) {
+      const returned = Math.max(
+        UserPreferenceUtils.dateToMinuteNumber(futureEventsOnThisDay[0].start_time) - currentMinutes - 1,
+        1
       );
+      return returned;
     }
 
-    return dayEnd - currentMinutes;
+    return minutesToDayEnd;
   }
 }


### PR DESCRIPTION
Fixed minutesToNextEvent function which was non-functional. The bug led to all generated events having the same length. Now it aligns with the actual amount of minutes the user has available, so there isn't overlap.

Relevant information could be found on Trello: https://trello.com/c/H1a54YOH/200-debug-events-generated-are-not-across-all-free-time-block-sometimes-overlap-pre-existing-events